### PR TITLE
Support external video buffer, Kickstart switching from keyboard

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,6 +3,14 @@
 ** Keir Fraser <keir.xen@gmail.com>
 ************************************
 
+** v1.x - xx September 2019
+ - Support Amiga keyboard for configuration and Gotek button presses and Kickstart selection
+   - L.Alt + L.Ctrl must be held to enable the following magic keys
+     - Left Arrow: Down/Left; Right Arrow: Up/Right; Up Arrow: Select
+     - HELP: Enter the FF OSD configuration menu
+     - F1..F4: Select ROM image
+     - F9,F10: Set output2 to low/high
+
 ** v1.2 - 20 September 2019
  - Move Gotek button outputs from C13-15 to A3-5
    - C13-15 are weak outputs

--- a/attic/pins.md
+++ b/attic/pins.md
@@ -8,11 +8,11 @@
 | 5 |    | Gotek Select  |    |                  |
 | 6 |    |               |  Y | I2C SCL          |
 | 7 |    |               |  Y | I2C SDA          |
-| 8 |  Y | CSYNC/HSYNC   |  Y |                  |
-| 9 |  Y | Serial Tx     |  Y |                  |
-|10 |  Y | Serial Rx     |  Y |                  |
+| 8 |  Y | CSYNC/HSYNC   |  Y | ROM0             |
+| 9 |  Y | Serial Tx     |  Y | ROM1             |
+|10 |  Y | Serial Rx     |  Y | Output2          |
 |11 |  Y |               |  Y | Atari KB         |
-|12 |  Y |               |  Y |                  |
+|12 |  Y |               |  Y | Disp.En.Out      |
 |13 |  Y | **NA** (SWDIO)|  Y |                  |
 |14 |  Y | **NA** (SWCLK)|  Y | VSYNC            |
 |15 |  Y |               |  Y | Disp.Out. (RGB)  |

--- a/inc/util.h
+++ b/inc/util.h
@@ -125,6 +125,8 @@ extern struct config {
 extern bool_t config_active;
 extern struct display config_display;
 
+void update_kickstart (void);
+
 /* Callbacks from configuration subsystem. */
 void slave_arr_update(void);
 void set_polarity(void);

--- a/inc/util.h
+++ b/inc/util.h
@@ -77,6 +77,12 @@ int printk(const char *format, ...)
 
 /* Amiga keyboard */
 #define AMI_F1     0x50
+#define AMI_F2     0x51
+#define AMI_F3     0x52
+#define AMI_F4     0x53
+#define AMI_F9     0x58
+#define AMI_F10    0x59
+#define AMI_HELP   0x5f
 #define AMI_L_CTRL 0x63
 #define AMI_L_ALT  0x64
 #define AMI_LEFT   0x4f

--- a/src/main.c
+++ b/src/main.c
@@ -331,6 +331,9 @@ static uint8_t keys;
 #define K_SELECT B_SELECT
 #define K_MENU   8
 
+static int kickstart = 3;
+static bool_t output2 = 1;
+
 static void update_amiga_keys(void)
 {
     keys = 0;
@@ -340,26 +343,69 @@ static void update_amiga_keys(void)
     if (amiga_key_pressed(AMI_HELP)) keys |= K_MENU;
 
     if (amiga_key_pressed(AMI_F1)) {
-        gpio_write_pin(gpio_rom0, pin_rom0, LOW);
-        gpio_write_pin(gpio_rom1, pin_rom1, LOW);
+        kickstart = 0;
+        update_kickstart();
     }
     if (amiga_key_pressed(AMI_F2)) {
-        gpio_write_pin(gpio_rom0, pin_rom0, HIGH);
-        gpio_write_pin(gpio_rom1, pin_rom1, LOW);
+        kickstart = 1;
+        update_kickstart();
     }
     if (amiga_key_pressed(AMI_F3)) {
-        gpio_write_pin(gpio_rom0, pin_rom0, LOW);
-        gpio_write_pin(gpio_rom1, pin_rom1, HIGH);
+        kickstart = 2;
+        update_kickstart();
     }
     if (amiga_key_pressed(AMI_F4)) {
-        gpio_write_pin(gpio_rom0, pin_rom0, HIGH);
-        gpio_write_pin(gpio_rom1, pin_rom1, HIGH);
+        kickstart = 3;
+        update_kickstart();
     }
     if (amiga_key_pressed(AMI_F9)) {
-        gpio_write_pin(gpio_out2, pin_out2, LOW);
+        output2 = 0;
+        update_kickstart();
     }
     if (amiga_key_pressed(AMI_F10)) {
-        gpio_write_pin(gpio_out2, pin_out2, HIGH);
+        output2 = 1;
+        update_kickstart();
+    }
+}
+
+void update_kickstart (void) {
+
+    switch (output2) {
+        case 0:
+            gpio_write_pin(gpio_out2, pin_out2, LOW);
+            break;
+
+        case 1:
+            gpio_write_pin(gpio_out2, pin_out2, HIGH);
+            break;
+
+        default:
+            break;
+    }
+
+    switch (kickstart) {
+        case 0:
+            gpio_write_pin(gpio_rom0, pin_rom0, LOW);
+            gpio_write_pin(gpio_rom1, pin_rom1, LOW);
+            break;
+
+        case 1:
+            gpio_write_pin(gpio_rom0, pin_rom0, HIGH);
+            gpio_write_pin(gpio_rom1, pin_rom1, LOW);
+            break;
+
+        case 2:
+            gpio_write_pin(gpio_rom0, pin_rom0, LOW);
+            gpio_write_pin(gpio_rom1, pin_rom1, HIGH);
+            break;
+
+        case 3:
+            gpio_write_pin(gpio_rom0, pin_rom0, HIGH);
+            gpio_write_pin(gpio_rom1, pin_rom1, HIGH);
+            break;
+
+        default:
+            break;
     }
 }
 


### PR DESCRIPTION
Moved config key to HELP

F1..F4 select kickstart roms with PB8, PB9

F9/F10 sets PB10 low/high for other uses (pal/ntsc, DF0/DF1 swap)

PB12 is used as an active high display enable to drive external buffer