### PR TITLE
Video pixel timing and polarity auto detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ export ROOT := $(CURDIR)
 
 all:
 	$(MAKE) -C src -f $(ROOT)/Rules.mk $(PROJ).elf $(PROJ).bin $(PROJ).hex
+debug:
+	debug=y $(MAKE) -C src -f $(ROOT)/Rules.mk $(PROJ).elf $(PROJ).bin $(PROJ).hex
 clean:
 	rm -rf $(PROJ)-$(VER)*
 	$(MAKE) -f $(ROOT)/Rules.mk $@

--- a/Rules.mk
+++ b/Rules.mk
@@ -13,6 +13,10 @@ FLAGS += -Wstrict-prototypes -Wredundant-decls -Wnested-externs
 FLAGS += -fno-common -fno-exceptions -fno-strict-aliasing
 FLAGS += -mlittle-endian -mthumb -mcpu=cortex-m3 -mfloat-abi=soft
 
+ifneq ($(debug),y)
+FLAGS += -DNDEBUG
+endif
+
 FLAGS += -MMD -MF .$(@F).d
 DEPS = .*.d
 

--- a/inc/config.h
+++ b/inc/config.h
@@ -14,6 +14,10 @@ enum dispen { DISPCTL_tristate = 0, DISPCTL_enable_high, DISPCTL_enable_low, DIS
  * PA15 is Display Enable: Active HIGH
  * PA15 is Display Enable: Active LOW */
 
+enum timings { DISP_15KHZ=0, DISP_VGA, DISP_AUTO, DISP_MAX };
+
+enum polarities { SYNC_LOW=0, SYNC_HIGH, SYNC_AUTO, SYNC_MAX };
+
 extern struct __packed config {
 
     uint16_t polarity;
@@ -24,11 +28,11 @@ extern struct __packed config {
 
     uint16_t rows;
 
-#define DISP_15KHZ 0
-#define DISP_VGA 1
+    /* timings enum
+     * DISP_15KHZ 0
+     * DISP_VGA   1
+     * DISP_AUTO  2 */
     uint16_t display_timing;
-
-    uint16_t display_autosync;
 
 #define DISP_SPI2 0
 #define DISP_SPI1 1

--- a/src/default_config.c
+++ b/src/default_config.c
@@ -19,7 +19,6 @@ const static struct config dfl_config = {
     .dispctl_mode = DISPCTL_tristate,
     .rows = 2,
     .display_timing = DISP_15KHZ,
-    .display_autosync = FALSE,
     .display_spi = DISP_SPI2,
     .display_2Y = FALSE,
 


### PR DESCRIPTION
Pixel Timing menu now has  VGA/15kHz/Auto
Sync Polarity can now be auto detected
Sync Polarity menu now has HIGH/LOW/Auto
show detected  polarity and timing in menu. eg: AUTO (15kHz)

Added debug=y and #NDEBUG
Amiga sync/display key shortcuts only work in debug build