### PR TITLE
Fix notify display for SPI1 w/ 36 MHz clock (VGA hires mode)

### DIFF
--- a/inc/stm32f10x_regs.h
+++ b/inc/stm32f10x_regs.h
@@ -262,6 +262,9 @@ struct rcc {
 #define RCC_AHBRSTR_ETHMACRST (1u<<14)
 #define RCC_AHBRSTR_OTGFSRST (1u<<12)
 
+#define RCC_APB1RSTR_SPI2RST (1u<< 14)
+#define RCC_APB2RSTR_SPI1RST (1u<< 12)
+
 #define RCC_BASE 0x40021000
 
 /* Independent Watchdog */

--- a/inc/util.h
+++ b/inc/util.h
@@ -46,6 +46,7 @@ void *memset(void *s, int c, size_t n);
 void *memcpy(void *dest, const void *src, size_t n);
 void *memmove(void *dest, const void *src, size_t n);
 
+#define LEN(arr) ((int) (sizeof (arr) / sizeof (arr)[0]))
 size_t strlen(const char *s);
 size_t strnlen(const char *s, size_t maxlen);
 int strcmp(const char *s1, const char *s2);


### PR DESCRIPTION
Fixes issue #45

The problem lies in the resizing of the OSD box outline. For SPI frequencies > 18 MHz, this leads to the OSD text disappearing.
The reason is not entirely clear, but keeping the OSD box at a constant (maximum) size eliminates the issue.

This PR also fixes SPI initialization by properly resetting and (re-)enabling the peripheral first.